### PR TITLE
fix: fix type annotations in doc comments

### DIFF
--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -198,7 +198,7 @@ function wpto_rest_permission_check( \WP_REST_Request $request ): bool {
  * Get tag order for a specific post.
  *
  * @param \WP_REST_Request $request REST request object.
- * @return \WP_REST_Response|WP_Error
+ * @return \WP_REST_Response|\WP_Error
  *
  * @phpstan-param WP_REST_Request<array{post_id?: int, taxonomy?: string}> $request
  */
@@ -241,7 +241,7 @@ function wpto_get_post_tag_order( \WP_REST_Request $request ): \WP_REST_Response
  * Update tag order for a specific post.
  *
  * @param \WP_REST_Request $request REST request object.
- * @return \WP_REST_Response
+ * @return \WP_REST_Response|\WP_Error
  *
  * @phpstan-param WP_REST_Request<array{post_id?: int, taxonomy?: string, tags?: string}> $request
  */


### PR DESCRIPTION
- [fix: fix type annotations in doc comments](https://github.com/sectsect/wp-tag-order/commit/52843947eb947de88baeac01ae91b22656a71fb5)