### PR TITLE
ci: add SVN installation step for WordPress test suite in GitHub Actions

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -42,6 +42,9 @@ jobs:
     - name: Check PHP Version
       run: php -v
 
+    - name: Install SVN
+      run: sudo apt-get update && sudo apt-get install -y subversion
+
     - name: Composer install
       run: composer install --optimize-autoloader --prefer-dist
 

--- a/wp-tag-order.php
+++ b/wp-tag-order.php
@@ -8,6 +8,8 @@
  * Text Domain:     wp-tag-order
  * Domain Path:     /languages
  * Version:         3.11.2
+ * License:         GPL-3.0-or-later
+ * License URI:     https://www.gnu.org/licenses/gpl-3.0.html
  *
  * @package         WP_Tag_Order
  */


### PR DESCRIPTION
ci: add SVN installation step for WordPress test suite in GitHub Actions