### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/sectsect/wp-tag-order/security/code-scanning/4](https://github.com/sectsect/wp-tag-order/security/code-scanning/4)

To fix this issue, add an explicit `permissions` block to the workflow. This block should grant only the minimum permissions required for the workflow to function. Based on the workflow's functionality—checking out code, setting up PHP, running Composer, and executing PHPStan—only `contents: read` permission is needed. This permission allows the workflow to read the repository content without granting write access, which is unnecessary for this use case.

The `permissions` block should be added at the root of the workflow so that it applies to all jobs within the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
