### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,5 +1,8 @@
 name: PHP Unit Tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/sectsect/wp-tag-order/security/code-scanning/3](https://github.com/sectsect/wp-tag-order/security/code-scanning/3)

To fix the issue, add a `permissions` block at the root of the workflow to define least-privilege access for all jobs. Given the tasks performed in the workflow, we can use `contents: read` as the minimal permission required, as the workflow does not perform any write operations on the repository. 

This change ensures the GITHUB_TOKEN is restricted to read-only access for repository contents, without affecting the functionality of the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
