### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+  pull-requests: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/sectsect/wp-tag-order/security/code-scanning/2](https://github.com/sectsect/wp-tag-order/security/code-scanning/2)

To address the issue, we will add a `permissions` key to the root of the workflow, limiting the permissions of the `GITHUB_TOKEN`. Since the workflow primarily involves reading repository contents and writing to pull requests, the permissions will be set to `contents: read` and `pull-requests: write`. This ensures the workflow operates with the minimal privileges necessary to complete its tasks.

Changes will be made to `.github/workflows/phpcs.yml`:
- Add a `permissions` block at the root level, applying the least privilege principle.
- This block will limit repository content access to `read` and allow `write` access only for pull requests.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
