### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -7,6 +7,9 @@ on: # rebuild any PRs and main branch changes
     - master
     - 'releases/*'
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/sectsect/wp-tag-order/security/code-scanning/1](https://github.com/sectsect/wp-tag-order/security/code-scanning/1)

To resolve the issue, the workflow should include an explicit `permissions` block to define the least privileges required for the GITHUB_TOKEN. In this workflow, only read access to repository contents is necessary since the plugin check operation does not modify the repository. The `permissions` block can be added at the root level of the workflow to apply to all jobs, as no job-specific permissions are required. This ensures security while maintaining the current functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
