### PR TITLE
ci(phpunit): fix mariadb version and remove wp-mysqli drop-in

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -21,7 +21,7 @@ jobs:
 
     services:
       mariadb:
-        image: mariadb:10.11
+        image: mariadb:lts
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: yes
         ports:

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -92,7 +92,6 @@ install_wp() {
 		tar --strip-components=1 -zxmf $TMPDIR/wordpress.tar.gz -C $WP_CORE_DIR
 	fi
 
-	download https://raw.github.com/markoheijnen/wp-mysqli/master/db.php $WP_CORE_DIR/wp-content/db.php
 }
 
 install_test_suite() {


### PR DESCRIPTION
- Replace `mariadb:10.11` with `mariadb:lts` in phpunit workflow
- Remove deprecated wp-mysqli db.php drop-in download from install-wp-tests.sh
